### PR TITLE
Update omv-compose-backup

### DIFF
--- a/usr/sbin/omv-compose-backup
+++ b/usr/sbin/omv-compose-backup
@@ -151,9 +151,33 @@ status="$(mktemp)"
 docker compose ls --all --format json | jq -r ".[] | select(.ConfigFiles | contains(\"${yml}\")) | .Status" > "${status}"
 _log "status :: $(cat "${status}")"
 
+wait_for_compose_to_exit() {
+  local attempt=0
+  local max_attempts=10
+
+  _log "Waiting for compose to fully stop..."
+
+  while [ $attempt -lt $max_attempts ]; do
+    current_status=$(docker compose ls --all --format json | jq -r ".[] | select(.ConfigFiles | contains(\"${yml}\")) | .Status")
+
+    if grep -q "exited" <(echo "${current_status}"); then
+      _log "compose stopped after $attempt millisecond(s): ${current_status}"
+      return 0
+    fi
+
+    _log "compose still stopping (attempt $((attempt+1))/${max_attempts}): ${current_status}"
+    ((attempt++))
+    sleep 0.001
+  done
+
+  _log "WARNING: compose might not be fully stopped after ${max_attempts} milliseconds. Proceeding anyway..."
+  return 1
+}
+
 # stop compose if running
 if grep -q "running" "${status}"; then
   docker compose "${dockerComposeArgs[@]}" stop
+  wait_for_compose_to_exit
 else
   _log "${compose} is not running"
 fi

--- a/usr/sbin/omv-compose-backup
+++ b/usr/sbin/omv-compose-backup
@@ -152,25 +152,27 @@ docker compose ls --all --format json | jq -r ".[] | select(.ConfigFiles | conta
 _log "status :: $(cat "${status}")"
 
 wait_for_compose_to_exit() {
+  local total_wait_s=10             # Total time to wait in seconds
+  local sleep_interval_s=0.1        # Sleep interval in seconds
+  local max_attempts=100            # Manually calculated as total_wait_s/sleep_interval_s
   local attempt=0
-  local max_attempts=10
 
-  _log "Waiting for compose to fully stop..."
+  _log "Waiting for compose to fully stop (max ${total_wait_s}s with ${sleep_interval_s}s intervals)..."
 
   while [ $attempt -lt $max_attempts ]; do
     current_status=$(docker compose ls --all --format json | jq -r ".[] | select(.ConfigFiles | contains(\"${yml}\")) | .Status")
 
     if grep -q "exited" <(echo "${current_status}"); then
-      _log "compose stopped after $attempt millisecond(s): ${current_status}"
+      _log "compose stopped: ${current_status}"
       return 0
     fi
 
     _log "compose still stopping (attempt $((attempt+1))/${max_attempts}): ${current_status}"
     ((attempt++))
-    sleep 0.001
+    sleep $sleep_interval_s
   done
 
-  _log "WARNING: compose might not be fully stopped after ${max_attempts} milliseconds. Proceeding anyway..."
+  _log "WARNING: compose might not be fully stopped after ${total_wait_s} seconds. Proceeding anyway..."
   return 1
 }
 


### PR DESCRIPTION
I came across a bug when I set a backup job to run daily on a searXNG container. I discovered that that waiting for `docker compose stop` does not mean the compose is fully stopped. In my case, the rsync was happening so fast that the script got to `docker compose start` before the stop was fully complete. The result is that the script exited while leaving the service in an exited state, as it was unable to restart it successfully. 

This simple change adds a polling mechanism to wait until it is completely stopped before proceeding. It has solved my problem completely.


## Testing
### Logs from before:
```
[2025-02-20 22:48:54-0500] [composebackup] uuid :: d7ff1f6c-8a37-4a55-b0fd-a38248139c72
[2025-02-20 22:48:54-0500] [composebackup] filter :: searxng
searxng
[2025-02-20 22:48:54-0500] [composebackup] compose :: searxng
[2025-02-20 22:48:54-0500] [composebackup] uuid :: d7ff1f6c-8a37-4a55-b0fd-a38248139c72
[2025-02-20 22:48:54-0500] [composebackup] Docker storage :: /var/lib/docker
[2025-02-20 22:48:54-0500] [composebackup] Compose file path :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/appdata
[2025-02-20 22:48:54-0500] [composebackup] Backup path :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/backup_appdata
[2025-02-20 22:48:54-0500] [composebackup] Compose file :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/appdata/searxng/searxng.yml
[2025-02-20 22:48:54-0500] [composebackup] Backup max size is set to unlimited.
[2025-02-20 22:48:54-0500] [composebackup] Backup max size :: 0 GB
[2025-02-20 22:48:54-0500] [composebackup] status :: running(1)
 Container searxng  Stopping
 Container searxng  Stopped
'/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/appdata/searxng/searxng.yml' -> '/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/backup_appdata/searxng/0/searxng.yml'
'/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/appdata/searxng/compose.override.yml' -> '/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/backup_appdata/searxng/0/compose.override.yml'
'/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/appdata/searxng/searxng.env' -> '/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/backup_appdata/searxng/0/searxng.env'
[2025-02-20 22:48:56-0500] [composebackup] Volume :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/data/searxng:/etc/searxng
[2025-02-20 22:48:56-0500] [composebackup] Backup host path :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/data/searxng
[2025-02-20 22:48:56-0500] [composebackup] Backup to :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/backup_appdata/searxng/1
sending incremental file list

sent 132 bytes  received 12 bytes  288.00 bytes/sec
total size is 1,983  speedup is 13.77

[2025-02-20 22:48:57-0500] [composebackup] Backup size :: 3570 bytes
[2025-02-20 22:48:57-0500] [composebackup] Done.
```

Notice that the "starting" and "started" logs are missing.

### Logs from after:
```
[2025-02-20 22:50:35-0500] [composebackup] uuid :: d7ff1f6c-8a37-4a55-b0fd-a38248139c72
[2025-02-20 22:50:35-0500] [composebackup] filter :: searxng
searxng
[2025-02-20 22:50:35-0500] [composebackup] compose :: searxng
[2025-02-20 22:50:35-0500] [composebackup] uuid :: d7ff1f6c-8a37-4a55-b0fd-a38248139c72
[2025-02-20 22:50:35-0500] [composebackup] Docker storage :: /var/lib/docker
[2025-02-20 22:50:35-0500] [composebackup] Compose file path :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/appdata
[2025-02-20 22:50:36-0500] [composebackup] Backup path :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/backup_appdata
[2025-02-20 22:50:36-0500] [composebackup] Compose file :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/appdata/searxng/searxng.yml
[2025-02-20 22:50:36-0500] [composebackup] Backup max size is set to unlimited.
[2025-02-20 22:50:36-0500] [composebackup] Backup max size :: 0 GB
[2025-02-20 22:50:36-0500] [composebackup] status :: running(1)
 Container searxng  Stopping
 Container searxng  Stopped
[2025-02-20 22:50:38-0500] [composebackup] Waiting for compose to fully stop...
[2025-02-20 22:50:38-0500] [composebackup] compose still stopping (attempt 1/10): running(1)
[2025-02-20 22:50:38-0500] [composebackup] compose still stopping (attempt 2/10): running(1)
[2025-02-20 22:50:38-0500] [composebackup] compose stopped after 2 millisecond(s): exited(1)
'/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/appdata/searxng/searxng.yml' -> '/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/backup_appdata/searxng/0/searxng.yml'
'/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/appdata/searxng/compose.override.yml' -> '/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/backup_appdata/searxng/0/compose.override.yml'
'/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/appdata/searxng/searxng.env' -> '/srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/backup_appdata/searxng/0/searxng.env'
[2025-02-20 22:50:38-0500] [composebackup] Volume :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/data/searxng:/etc/searxng
[2025-02-20 22:50:38-0500] [composebackup] Backup host path :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/data/searxng
[2025-02-20 22:50:38-0500] [composebackup] Backup to :: /srv/dev-disk-by-uuid-a490e1fe-6839-4e06-a811-13f982416eea/system/backup_appdata/searxng/1
sending incremental file list

sent 132 bytes  received 12 bytes  288.00 bytes/sec
total size is 1,983  speedup is 13.77

 Container searxng  Starting
 Container searxng  Started
[2025-02-20 22:50:39-0500] [composebackup] Backup size :: 3570 bytes
[2025-02-20 22:50:39-0500] [composebackup] Done.

```