### PR TITLE
Make use of the icons defined in core framework

### DIFF
--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-containers-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-containers-datatable-page.yaml
@@ -150,7 +150,7 @@ data:
                   command2: "--follow"
                   id: "{{ _selected[0].id }}"
       - type: iconButton
-        icon: mdi:download
+        icon: "download"
         tooltip: _("Download log")
         enabledConstraints:
           minSelected: 1

--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-files-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-files-datatable-page.yaml
@@ -280,7 +280,7 @@ data:
                   uuid: "{{ _selected[0].uuid }}"
                   command: "up -d"
       - type: iconButton
-        icon: mdi:stop
+        icon: "stop"
         tooltip: _("stop")
         enabledConstraints:
           minSelected: 1
@@ -467,7 +467,7 @@ data:
                       command: "logs"
                       command2: "--follow"
           - text: _("Download logs")
-            icon: mdi:download
+            icon: "download"
             enabledConstraints:
               minSelected: 1
               maxSelected: 1

--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-files-example-form-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-files-example-form-page.yaml
@@ -35,7 +35,7 @@ data:
         sortable: true
     actions:
       - type: iconButton
-        icon: mdi:plus-box
+        icon: "add"
         tooltip: _("Add example compose file")
         enabledConstraints:
           minSelected: 1

--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-images-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-images-datatable-page.yaml
@@ -87,7 +87,7 @@ data:
         cellTemplateName: checkIcon
     actions:
       - type: iconButton
-        icon: mdi:delete
+        icon: "delete"
         tooltip: _("Delete")
         enabledConstraints:
           minSelected: 1

--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-networks-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-networks-datatable-page.yaml
@@ -33,7 +33,7 @@ data:
           type: url
           url: "/services/compose/networks/create"
       - type: iconButton
-        icon: mdi:delete
+        icon: "delete"
         tooltip: _("Delete")
         enabledConstraints:
           minSelected: 1

--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-restore-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-restore-datatable-page.yaml
@@ -31,7 +31,7 @@ data:
     actions:
       - type: iconButton
         tooltip: _("Restore")
-        icon: mdi:restore
+        icon: "restore"
         enabledConstraints:
           minSelected: 1
           maxSelected: 1
@@ -60,7 +60,7 @@ data:
             progressMessage: _("Restoring global.env from backup ...")
             successNotification: _("global.env has been restored from backup.")
       - type: iconButton
-        icon: mdi:delete
+        icon: "delete"
         tooltip: _("Delete")
         confirmationDialogConfig:
           template: confirmation-danger

--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-services-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-services-datatable-page.yaml
@@ -120,7 +120,7 @@ data:
                   envpath: "{{ _selected[0].envpath }}"
                   overridepath: "{{ _selected[0].overridepath }}"
       - type: iconButton
-        icon: mdi:stop
+        icon: "stop"
         tooltip: _("stop")
         enabledConstraints:
           minSelected: 1
@@ -249,7 +249,7 @@ data:
                   envpath: "{{ _selected[0].envpath }}"
                   overridepath: "{{ _selected[0].overridepath }}"
       - type: iconButton
-        icon: mdi:download
+        icon: "download"
         tooltip: _("Download log")
         enabledConstraints:
           minSelected: 1

--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-stats-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-stats-datatable-page.yaml
@@ -165,7 +165,7 @@ data:
                   cmd2: ""
                   id: "{{ _selected[0].id }}"
       - type: iconButton
-        icon: mdi:download
+        icon: "download"
         tooltip: _("Download log")
         enabledConstraints:
           minSelected: 1

--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-volumes-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-volumes-datatable-page.yaml
@@ -39,7 +39,7 @@ data:
         sortable: true
     actions:
       - type: iconButton
-        icon: mdi:delete
+        icon: "delete"
         tooltip: _("Delete")
         enabledConstraints:
           minSelected: 1


### PR DESCRIPTION
The default icons are specified here: https://github.com/openmediavault/openmediavault/blob/68a3c90cbe6f838227d26cbd28b3f37fc91d80dd/deb/openmediavault/workbench/src/app/shared/enum/icon.enum.ts#L19