### PR TITLE
Clarify image tag dialog by distinguishing current info from target inputs

### DIFF
--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-images-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-images-datatable-page.yaml
@@ -185,24 +185,25 @@ data:
             fields:
               - type: textInput
                 name: repo
-                label: _('Repository')
+                label: _('Current repository')
                 value: '{{ _selected[0].repo }}'
-                readonly: true
-                submitValue: false
+                disabled: true
               - type: textInput
                 name: tag
-                label: _('Tag')
+                label: _('Current tag')
                 value: '{{ _selected[0].tag }}'
-                readonly: true
-                submitValue: false
-              - type: textInput
+                disabled: true
+              - type: hidden
                 name: srcid
+                value: '{{ _selected[0].id }}'
+              - type: textInput
+                name: srcid_visible
                 label: _('Image ID')
                 value: '{{ _selected[0].id }}'
-                readonly: true
+                disabled: true
               - type: textInput
                 name: tgtimg
-                label: _('Target repo')
+                label: _('Target repository')
                 value: '{{ _selected[0].repo }}'
               - type: textInput
                 name: tgttag


### PR DESCRIPTION
This clarifies the image tag dialog by
- renaming labels to `Current repository`, `Current tag`, `Image ID`, `Target repository`, `Target tag`
- using `disabled: true` for those inputs, that user cannot edit, which leads to a more clear visual effect

-> `srcid` submission still works because of a 2nd `srcid` field with `type: hidden` (values of disabled textInputs cannot be submitted)

I tested it and tagging functionality works fine.

|Before|After|
|-|-|
|<img width="527" height="475" alt="grafik" src="https://github.com/user-attachments/assets/67877e84-fd21-493d-b481-14880a46c7f3" />|<img width="522" height="470" alt="grafik" src="https://github.com/user-attachments/assets/fc4c14f2-ef54-4dee-a672-50f4960c9d4e" />|