### PR TITLE
Add idempotent OMV Docker setup scripts

### DIFF
--- a/tools/omv-setup/.gitignore
+++ b/tools/omv-setup/.gitignore
@@ -1,0 +1,1 @@
+.sf-uuids

--- a/tools/omv-setup/01-groups.sh
+++ b/tools/omv-setup/01-groups.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+# System docker group (for /var/run/docker.sock access)
+if getent group "$DOCKER_GROUP" >/dev/null 2>&1; then
+  log "Group '$DOCKER_GROUP' already exists"
+else
+  groupadd "$DOCKER_GROUP"
+  log "Created group '$DOCKER_GROUP'"
+fi
+
+# Organizational group (for data directory ownership)
+if getent group "$SVC_GROUP" >/dev/null 2>&1; then
+  log "Group '$SVC_GROUP' already exists"
+else
+  groupadd "$SVC_GROUP"
+  log "Created group '$SVC_GROUP'"
+fi

--- a/tools/omv-setup/02-service-user.sh
+++ b/tools/omv-setup/02-service-user.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+if id "$SVC_USER" >/dev/null 2>&1; then
+  log "User '$SVC_USER' already exists"
+else
+  useradd --system --no-create-home --shell /usr/sbin/nologin --gid "$SVC_GROUP" "$SVC_USER"
+  log "Created user '$SVC_USER' (primary group: $SVC_GROUP)"
+fi
+
+# Ensure supplementary docker group membership
+if id -nG "$SVC_USER" | grep -qw "$DOCKER_GROUP"; then
+  log "$SVC_USER already in $DOCKER_GROUP"
+else
+  usermod -aG "$DOCKER_GROUP" "$SVC_USER"
+  log "Added $SVC_USER to $DOCKER_GROUP"
+fi

--- a/tools/omv-setup/03-calling-user.sh
+++ b/tools/omv-setup/03-calling-user.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+if [[ "$CALLING_USER" == "root" ]]; then
+  log "Running as root directly, skipping group additions"
+  exit 0
+fi
+
+for grp in "$DOCKER_GROUP" "$SVC_GROUP"; do
+  if id -nG "$CALLING_USER" | grep -qw "$grp"; then
+    log "$CALLING_USER already in $grp"
+  else
+    usermod -aG "$grp" "$CALLING_USER"
+    log "Added $CALLING_USER to $grp (re-login to take effect)"
+  fi
+done

--- a/tools/omv-setup/04-install-omv-extras.sh
+++ b/tools/omv-setup/04-install-omv-extras.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+if dpkg -l openmediavault-omvextrasorg 2>/dev/null | grep -q '^ii'; then
+  log "omv-extras already installed"
+  exit 0
+fi
+
+log "Installing omv-extras..."
+wget -qO /tmp/omv-extras-install.sh \
+  https://github.com/OpenMediaVault-Plugin-Developers/installScript/raw/master/install
+bash /tmp/omv-extras-install.sh
+rm -f /tmp/omv-extras-install.sh
+log "omv-extras installed"

--- a/tools/omv-setup/05-install-omv-compose.sh
+++ b/tools/omv-setup/05-install-omv-compose.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+if dpkg -l openmediavault-compose 2>/dev/null | grep -q '^ii'; then
+  log "openmediavault-compose already installed"
+  exit 0
+fi
+
+log "Installing openmediavault-compose..."
+apt-get update -qq
+apt-get install -y openmediavault-compose
+log "openmediavault-compose installed"

--- a/tools/omv-setup/06-install-docker.sh
+++ b/tools/omv-setup/06-install-docker.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+if dpkg -l docker-ce 2>/dev/null | grep -q '^ii'; then
+  log "Docker CE already installed"
+  exit 0
+fi
+
+log "Installing Docker via OMV salt state..."
+
+# Enable docker apt repo through OMV's mechanism
+. /etc/default/openmediavault 2>/dev/null || true
+omv_rpc "OmvExtras" "setDocker" '{"docker":true}' 2>/dev/null || \
+  omv_rpc "OmvExtras" "set" '{"docker":true}' 2>/dev/null || true
+
+# Refresh apt sources
+omv-aptclean repos 2>/dev/null || true
+apt-get update -qq
+
+# Deploy via salt -- this runs 30docker.sls which installs:
+# containerd.io, docker-ce, docker-ce-cli, docker-compose-plugin, docker-buildx-plugin
+# and configures daemon.json + systemd overrides
+omv-salt deploy run compose
+
+log "Docker CE installed via omv-salt"

--- a/tools/omv-setup/07-data-dirs.sh
+++ b/tools/omv-setup/07-data-dirs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+for dir in "${DATA_DIRS[@]}"; do
+  path="$DATA_ROOT/$dir"
+
+  if [[ ! -d "$path" ]]; then
+    mkdir -p "$path"
+    log "Created $path"
+  fi
+
+  current_owner=$(stat -c '%U:%G' "$path")
+  expected="$SVC_USER:$SVC_GROUP"
+  if [[ "$current_owner" != "$expected" ]]; then
+    log "WARN: $path owned by $current_owner, changing to $expected"
+  fi
+  chown "$SVC_USER:$SVC_GROUP" "$path"
+  chmod "$COMPOSE_DIR_MODE" "$path"
+done
+
+log "Data dirs ready: $DATA_ROOT/{${DATA_DIRS[*]}}"

--- a/tools/omv-setup/08-register-shares.sh
+++ b/tools/omv-setup/08-register-shares.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SF_UUIDS_FILE="$SCRIPT_DIR/.sf-uuids"
+
+# Find the mount point backing DATA_ROOT
+MOUNT_POINT="$(df --output=target "$DATA_ROOT" 2>/dev/null | tail -1)"
+[[ -n "$MOUNT_POINT" ]] || { log "ERROR: cannot determine mount point for $DATA_ROOT"; exit 1; }
+
+# Find the OMV mntent UUID for that mount point
+find_mntentref() {
+  omv_rpc "FsTab" "enumerateEntries" '{}' | python3 -c "
+import sys, json
+mount = '$MOUNT_POINT'.rstrip('/')
+entries = json.load(sys.stdin)
+for e in entries:
+    if e.get('dir','').rstrip('/') == mount:
+        print(e['uuid'])
+        sys.exit(0)
+# Fallback: try matching by prefix for nested mounts
+for e in entries:
+    if mount.startswith(e.get('dir','').rstrip('/')):
+        print(e['uuid'])
+        sys.exit(0)
+sys.exit(1)
+"
+}
+
+MNTENTREF="$(find_mntentref)" || { log "ERROR: no OMV filesystem entry for $MOUNT_POINT"; exit 1; }
+log "Found mntentref=$MNTENTREF for $MOUNT_POINT"
+
+# Check if a shared folder already exists by name, return its UUID or empty
+sf_exists() {
+  local name="$1"
+  omv_rpc "ShareMgmt" "getList" '{"start":0,"limit":200}' | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for e in data.get('data', data if isinstance(data, list) else []):
+    if e.get('name') == '$name':
+        print(e['uuid'])
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null
+}
+
+# Register a shared folder, return its UUID
+register_sf() {
+  local name="$1" relpath="$2" comment="$3"
+  local existing
+  if existing="$(sf_exists "$name")"; then
+    log "Shared folder '$name' already registered ($existing)"
+    echo "$existing"
+    return 0
+  fi
+
+  local result
+  result=$(omv_rpc "ShareMgmt" "set" "{
+    \"uuid\": \"$OMV_NEW_UUID\",
+    \"name\": \"$name\",
+    \"mntentref\": \"$MNTENTREF\",
+    \"reldirpath\": \"$relpath/\",
+    \"comment\": \"$comment\",
+    \"privileges\": {\"privilege\": []}
+  }")
+
+  # Extract UUID from response
+  local uuid
+  uuid=$(echo "$result" | python3 -c "import sys,json; print(json.load(sys.stdin).get('uuid',''))" 2>/dev/null)
+  if [[ -z "$uuid" ]]; then
+    # Fetch it back by name
+    uuid="$(sf_exists "$name")" || { log "ERROR: failed to create shared folder '$name'"; return 1; }
+  fi
+  log "Created shared folder '$name' -> $uuid"
+  echo "$uuid"
+}
+
+# Compute relative path from mount point
+rel_from_mount() {
+  local full="$DATA_ROOT/$1"
+  echo "${full#$MOUNT_POINT/}"
+}
+
+SF_COMPOSE_UUID="$(register_sf "compose" "$(rel_from_mount compose)" "Docker compose files")"
+SF_APPDATA_UUID="$(register_sf "appdata" "$(rel_from_mount appdata)" "Docker container data")"
+SF_BACKUP_UUID="$(register_sf "backup" "$(rel_from_mount backup)" "Docker backup storage")"
+SF_SHARE_UUID="$(register_sf "share" "$(rel_from_mount share)" "Docker shared data")"
+
+# Persist UUIDs for 09-configure-compose.sh
+cat > "$SF_UUIDS_FILE" <<EOF
+SF_COMPOSE_UUID=$SF_COMPOSE_UUID
+SF_APPDATA_UUID=$SF_APPDATA_UUID
+SF_BACKUP_UUID=$SF_BACKUP_UUID
+SF_SHARE_UUID=$SF_SHARE_UUID
+EOF
+
+log "All shared folders registered"

--- a/tools/omv-setup/09-configure-compose.sh
+++ b/tools/omv-setup/09-configure-compose.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SF_UUIDS_FILE="$SCRIPT_DIR/.sf-uuids"
+
+[[ -f "$SF_UUIDS_FILE" ]] || { log "ERROR: run 08-register-shares.sh first"; exit 1; }
+source "$SF_UUIDS_FILE"
+
+# Read current compose settings
+CURRENT=$(omv_rpc "Compose" "get" '{}')
+
+# Check which fields would change (only flag non-empty -> different)
+CHANGES=$(python3 -c "
+import sys, json
+c = json.loads(sys.stdin.read())
+desired = {
+    'sharedfolderref': '$SF_COMPOSE_UUID',
+    'datasharedfolderref': '$SF_APPDATA_UUID',
+    'backupsharedfolderref': '$SF_BACKUP_UUID',
+    'composeowner': '$SVC_USER',
+    'composegroup': '$SVC_GROUP',
+}
+changes = []
+for k, v in desired.items():
+    cur = c.get(k, '')
+    if cur and cur != v:
+        changes.append(f'  {k}: {cur} -> {v}')
+print('\n'.join(changes))
+" <<< "$CURRENT")
+
+if [[ -n "$CHANGES" ]]; then
+  log "The following settings would change:"
+  echo "$CHANGES"
+  if [[ "${OMV_FORCE:-}" == "1" ]]; then
+    log "OMV_FORCE=1, applying..."
+  elif [[ "${OMV_NONINTERACTIVE:-}" == "1" ]]; then
+    log "OMV_NONINTERACTIVE=1, skipping overwrites"
+    exit 0
+  else
+    read -rp "[omv-setup] Apply these changes? [y/N] " answer
+    [[ "$answer" =~ ^[Yy] ]] || { log "Skipped"; exit 0; }
+  fi
+fi
+
+# Apply: read-modify-write
+UPDATED=$(python3 -c "
+import sys, json
+c = json.loads(sys.stdin.read())
+c['sharedfolderref'] = '$SF_COMPOSE_UUID'
+c['datasharedfolderref'] = '$SF_APPDATA_UUID'
+c['backupsharedfolderref'] = '$SF_BACKUP_UUID'
+c['composeowner'] = '$SVC_USER'
+c['composegroup'] = '$SVC_GROUP'
+print(json.dumps(c))
+" <<< "$CURRENT")
+
+omv_rpc "Compose" "set" "$UPDATED"
+log "Compose settings updated: owner=$SVC_USER, group=$SVC_GROUP"

--- a/tools/omv-setup/10-scheduled-jobs.sh
+++ b/tools/omv-setup/10-scheduled-jobs.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+# Check if a job with our comment marker already exists
+job_exists() {
+  local marker="$1"
+  omv_rpc "Compose" "getJobList" '{"start":0,"limit":100,"sortfield":"comment","sortdir":"ASC"}' | \
+    python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+items = data.get('data', data if isinstance(data, list) else [])
+for e in items:
+    if e.get('comment','') == '$marker':
+        sys.exit(0)
+sys.exit(1)
+" 2>/dev/null
+}
+
+create_job() {
+  local comment="$1"
+  local json_override="$2"
+
+  if job_exists "$comment"; then
+    log "Job '$comment' already exists"
+    return 0
+  fi
+
+  # Base template with all required fields
+  local params
+  params=$(python3 -c "
+import json
+base = {
+    'uuid': '$OMV_NEW_UUID',
+    'enable': True,
+    'filter': '*',
+    'excludefilter': '',
+    'backup': False,
+    'prebackup': '',
+    'postbackup': '',
+    'maintenance': False,
+    'cstate': False,
+    'cbuild': False,
+    'update': False,
+    'prune': False,
+    'filestart': False,
+    'filestop': False,
+    'filebuild': False,
+    'filepull': False,
+    'filenocache': False,
+    'fileprunebuilder': False,
+    'sendemail': False,
+    'emailonerror': False,
+    'verbose': False,
+    'skipstartstop': False,
+    'comment': '$comment',
+    'excludes': '',
+    'execution': 'daily',
+    'minute': ['0'],
+    'everynminute': False,
+    'hour': ['2'],
+    'everynhour': False,
+    'dayofmonth': ['*'],
+    'everyndayofmonth': False,
+    'month': ['*'],
+    'dayofweek': ['*'],
+}
+override = json.loads('$json_override')
+base.update(override)
+print(json.dumps(base))
+")
+
+  omv_rpc "Compose" "setJob" "$params" >/dev/null
+  log "Created job '$comment'"
+}
+
+# Daily backup at 2:00 AM
+create_job "omv-setup: daily backup" '{"backup":true,"maintenance":true,"hour":["2"],"minute":["0"]}'
+
+# Weekly update check on Sundays at 3:00 AM
+create_job "omv-setup: weekly update" '{"update":true,"execution":"weekly","hour":["3"],"minute":["0"],"dayofweek":["7"]}'
+
+# Weekly prune on Sundays at 4:00 AM
+create_job "omv-setup: weekly prune" '{"prune":true,"execution":"weekly","hour":["4"],"minute":["0"],"dayofweek":["7"]}'
+
+log "Scheduled jobs configured"

--- a/tools/omv-setup/11-deploy.sh
+++ b/tools/omv-setup/11-deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+need_root
+
+log "Applying configuration via omv-salt..."
+omv-salt deploy run compose
+log "Deploy complete -- all config applied"

--- a/tools/omv-setup/README.md
+++ b/tools/omv-setup/README.md
@@ -1,0 +1,87 @@
+# OMV Docker Setup
+
+Idempotent setup scripts for OpenMediaVault + Docker + Compose. Automates what
+you'd otherwise click through in the OMV web UI.
+
+## What it does
+
+1. Creates groups (`grp_docker` for data ownership, system `docker` for socket access)
+2. Creates a service account (`svc_docker`) in both groups
+3. Adds the calling user to both groups
+4. Installs omv-extras, omv-compose, and Docker CE (via OMV's salt states)
+5. Creates data directories at `/mnt/data/{appdata,compose,backup,share}`
+6. Registers them as OMV shared folders (visible in the UI)
+7. Configures the compose plugin (owner, group, shared folder assignments)
+8. Creates scheduled jobs (daily backup, weekly update, weekly prune)
+9. Deploys all config via `omv-salt`
+
+## Usage
+
+```bash
+# Full setup -- clone and run
+git clone https://github.com/sdthach/openmediavault-compose /tmp/omv-compose
+sudo bash /tmp/omv-compose/tools/omv-setup/setup.sh
+
+# Or curl the orchestrator (downloads all scripts)
+curl -sL https://raw.githubusercontent.com/sdthach/openmediavault-compose/master/tools/omv-setup/setup.sh | sudo bash
+
+# Run a single step
+sudo bash tools/omv-setup/07-data-dirs.sh
+```
+
+## Configuration
+
+Override defaults via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OMV_SVC_USER` | `svc_docker` | Service account name |
+| `OMV_SVC_GROUP` | `grp_docker` | Organizational group for data dirs |
+| `OMV_DATA_ROOT` | `/mnt/data` | Root path for data directories |
+| `OMV_NONINTERACTIVE` | unset | Set to `1` to skip overwrite prompts (safe: skips changes) |
+| `OMV_FORCE` | unset | Set to `1` to apply all changes without prompting |
+
+Example:
+
+```bash
+OMV_SVC_USER=svc_media OMV_SVC_GROUP=grp_media OMV_DATA_ROOT=/srv/docker sudo bash setup.sh
+```
+
+## Naming convention
+
+| Prefix | Use | Examples |
+|--------|-----|----------|
+| `svc_` | Service accounts (non-interactive) | `svc_docker`, `svc_backup` |
+| `grp_` | Permission groups | `grp_docker`, `grp_developers` |
+| `app_` | Application-specific groups | `app_nginx`, `app_confluence` |
+| `team_` | Team-scoped groups | `team_devops` |
+
+## Script order
+
+| # | Script | What it does |
+|---|--------|--------------|
+| 01 | `01-groups.sh` | Create `grp_docker` + system `docker` group |
+| 02 | `02-service-user.sh` | Create `svc_docker` (primary: grp_docker, supplementary: docker) |
+| 03 | `03-calling-user.sh` | Add SSH caller to both groups |
+| 04 | `04-install-omv-extras.sh` | Install omv-extras plugin |
+| 05 | `05-install-omv-compose.sh` | Install openmediavault-compose package |
+| 06 | `06-install-docker.sh` | Install Docker via `omv-salt deploy run compose` |
+| 07 | `07-data-dirs.sh` | Create data dirs, enforce ownership |
+| 08 | `08-register-shares.sh` | Register dirs as OMV shared folders |
+| 09 | `09-configure-compose.sh` | Set compose plugin settings |
+| 10 | `10-scheduled-jobs.sh` | Create backup/update/prune cron jobs |
+| 11 | `11-deploy.sh` | Apply all config via salt |
+
+## Safety
+
+- **Idempotent**: re-run anytime. Each script checks state before acting.
+- **Non-destructive**: existing settings prompt before overwrite (unless `OMV_FORCE=1`).
+- **Ownership enforcement**: dirs always get corrected ownership, with a warning if changed.
+- **OMV-native**: all config goes through `omv-rpc` (same API as the web UI). Nothing bypassed.
+
+## Requirements
+
+- OpenMediaVault 7.x installed
+- Root access (sudo)
+- Network access (for package downloads)
+- A mounted filesystem at `DATA_ROOT` already registered in OMV

--- a/tools/omv-setup/common.sh
+++ b/tools/omv-setup/common.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Sourced by all scripts. Not executable on its own.
+set -euo pipefail
+
+# -- Configurable via environment --
+SVC_USER="${OMV_SVC_USER:-svc_docker}"
+SVC_GROUP="${OMV_SVC_GROUP:-grp_docker}"
+DOCKER_GROUP="docker"
+DATA_ROOT="${OMV_DATA_ROOT:-/mnt/data}"
+DATA_DIRS=(appdata compose backup share)
+COMPOSE_DIR_MODE="750"
+COMPOSE_FILE_MODE="640"
+
+# The human who SSH'd in (works through sudo)
+CALLING_USER="${SUDO_USER:-$(logname 2>/dev/null || echo root)}"
+
+# OMV's sentinel UUID for "create new object"
+OMV_NEW_UUID="fa4b1c66-ef79-11e5-87a0-0002b3a176b4"
+
+# -- Helpers --
+
+log() { echo "[omv-setup] $*"; }
+
+need_root() {
+  [[ $EUID -eq 0 ]] || { log "ERROR: must run as root (use sudo)"; exit 1; }
+}
+
+omv_rpc() {
+  local service="$1" method="$2" params="${3:-{}}"
+  omv-rpc -u admin "$service" "$method" "$params"
+}

--- a/tools/omv-setup/setup.sh
+++ b/tools/omv-setup/setup.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# If piped via curl, download all scripts first
+if [[ ! -f "$DIR/common.sh" ]]; then
+  REPO="https://raw.githubusercontent.com/sdthach/openmediavault-compose/master/tools/omv-setup"
+  DIR="/tmp/omv-setup-$$"
+  mkdir -p "$DIR"
+  for f in common.sh 01-groups.sh 02-service-user.sh 03-calling-user.sh \
+           04-install-omv-extras.sh 05-install-omv-compose.sh 06-install-docker.sh \
+           07-data-dirs.sh 08-register-shares.sh 09-configure-compose.sh \
+           10-scheduled-jobs.sh 11-deploy.sh; do
+    curl -sfL "$REPO/$f" -o "$DIR/$f"
+  done
+  trap "rm -rf $DIR" EXIT
+fi
+
+source "$DIR/common.sh"
+need_root
+
+log "Starting OMV Docker setup"
+log "  SVC_USER=$SVC_USER  SVC_GROUP=$SVC_GROUP  DOCKER_GROUP=$DOCKER_GROUP"
+log "  DATA_ROOT=$DATA_ROOT  CALLING_USER=$CALLING_USER"
+echo ""
+
+for script in "$DIR"/[0-9][0-9]-*.sh; do
+  echo "=== $(basename "$script") ==="
+  bash "$script"
+  echo ""
+done
+
+log "Setup complete"

--- a/tools/omv-setup/tests/Dockerfile
+++ b/tools/omv-setup/tests/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash coreutils python3 grep sed && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install mock OMV CLI tools
+COPY tests/mock-omv-rpc /usr/local/bin/omv-rpc
+COPY tests/mock-omv-salt /usr/local/bin/omv-salt
+COPY tests/mock-omv-aptclean /usr/local/bin/omv-aptclean
+RUN chmod +x /usr/local/bin/omv-rpc /usr/local/bin/omv-salt /usr/local/bin/omv-aptclean
+
+# Create the data root mount point
+RUN mkdir -p /mnt/data
+
+# Copy scripts
+COPY . /opt/omv-setup/
+RUN chmod +x /opt/omv-setup/*.sh /opt/omv-setup/tests/*.sh
+
+WORKDIR /opt/omv-setup
+CMD ["bash", "tests/run-tests.sh"]

--- a/tools/omv-setup/tests/mock-omv-aptclean
+++ b/tools/omv-setup/tests/mock-omv-aptclean
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+# Mock omv-aptclean: no-op

--- a/tools/omv-setup/tests/mock-omv-rpc
+++ b/tools/omv-setup/tests/mock-omv-rpc
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Mock omv-rpc: pattern-matches service+method, returns canned JSON.
+# Tests control state via /tmp/omv-mock-*.json files.
+
+# omv-rpc -u admin "Service" "method" '{params}'
+# $1=-u $2=admin $3=Service $4=method $5=params
+SERVICE="$3"
+METHOD="$4"
+
+case "$SERVICE:$METHOD" in
+  FsTab:enumerateEntries)
+    echo '[{"uuid":"fake-mntent-uuid","dir":"/","fsname":"/dev/sda1","type":"ext4","opts":"defaults","freq":0,"passno":0},{"uuid":"fake-mntent-data","dir":"/mnt/data","fsname":"/dev/sdb1","type":"ext4","opts":"defaults","freq":0,"passno":0}]'
+    ;;
+  ShareMgmt:getList)
+    if [[ -f /tmp/omv-mock-shares.json ]]; then
+      cat /tmp/omv-mock-shares.json
+    else
+      echo '{"total":0,"data":[]}'
+    fi
+    ;;
+  ShareMgmt:set)
+    echo '{"uuid":"new-sf-uuid-1234"}'
+    ;;
+  Compose:get)
+    if [[ -f /tmp/omv-mock-compose.json ]]; then
+      cat /tmp/omv-mock-compose.json
+    else
+      echo '{"sharedfolderref":"","datasharedfolderref":"","backupsharedfolderref":"","composeowner":"","composegroup":"","mode":"750","fileperms":"640"}'
+    fi
+    ;;
+  Compose:set)
+    # Store what was passed for assertion
+    echo "$5" > /tmp/omv-mock-compose-last-set.json
+    echo '{}'
+    ;;
+  Compose:getJobList)
+    if [[ -f /tmp/omv-mock-jobs.json ]]; then
+      cat /tmp/omv-mock-jobs.json
+    else
+      echo '{"total":0,"data":[]}'
+    fi
+    ;;
+  Compose:setJob)
+    echo "$5" >> /tmp/omv-mock-jobs-created.json
+    echo '{"uuid":"new-job-uuid-1234"}'
+    ;;
+  OmvExtras:setDocker|OmvExtras:set)
+    echo '{}'
+    ;;
+  *)
+    echo '{}'
+    ;;
+esac

--- a/tools/omv-setup/tests/mock-omv-salt
+++ b/tools/omv-setup/tests/mock-omv-salt
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Mock omv-salt: no-op, just logs what was called
+echo "[mock-omv-salt] $*" >> /tmp/omv-mock-salt.log

--- a/tools/omv-setup/tests/run-tests.sh
+++ b/tools/omv-setup/tests/run-tests.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT_DIR="/opt/omv-setup"
+pass=0
+fail=0
+
+assert() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  PASS: $desc"; ((pass++))
+  else
+    echo "  FAIL: $desc"; ((fail++))
+  fi
+}
+
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $desc"; ((pass++))
+  else
+    echo "  FAIL: $desc (expected='$expected', got='$actual')"; ((fail++))
+  fi
+}
+
+reset_mocks() {
+  rm -f /tmp/omv-mock-*.json /tmp/omv-mock-*.log
+}
+
+# ============================================================
+echo "=== 01-groups.sh ==="
+reset_mocks
+
+bash "$SCRIPT_DIR/01-groups.sh"
+assert "grp_docker group created" getent group grp_docker
+assert "docker group created" getent group docker
+
+# Idempotent
+bash "$SCRIPT_DIR/01-groups.sh"
+assert "idempotent: no error on rerun" true
+
+# ============================================================
+echo ""
+echo "=== 02-service-user.sh ==="
+
+bash "$SCRIPT_DIR/02-service-user.sh"
+assert "svc_docker user created" id svc_docker
+assert_eq "primary group is grp_docker" "grp_docker" "$(id -gn svc_docker)"
+assert "svc_docker in docker group" bash -c "id -nG svc_docker | grep -qw docker"
+
+# Idempotent
+bash "$SCRIPT_DIR/02-service-user.sh"
+assert "idempotent: no error on rerun" true
+
+# ============================================================
+echo ""
+echo "=== 03-calling-user.sh ==="
+
+# Create a test user to act as the "SSH caller"
+useradd --create-home testcaller 2>/dev/null || true
+export SUDO_USER=testcaller
+
+bash "$SCRIPT_DIR/03-calling-user.sh"
+assert "testcaller in docker group" bash -c "id -nG testcaller | grep -qw docker"
+assert "testcaller in grp_docker group" bash -c "id -nG testcaller | grep -qw grp_docker"
+
+# Idempotent
+bash "$SCRIPT_DIR/03-calling-user.sh"
+assert "idempotent: no error on rerun" true
+
+# Root case: should skip gracefully
+unset SUDO_USER
+bash "$SCRIPT_DIR/03-calling-user.sh"
+assert "root case: exits cleanly" true
+
+# Restore for subsequent scripts
+export SUDO_USER=testcaller
+
+# ============================================================
+echo ""
+echo "=== 07-data-dirs.sh ==="
+
+# Clean slate
+rm -rf /mnt/data/{appdata,compose,backup,share}
+
+bash "$SCRIPT_DIR/07-data-dirs.sh"
+assert "appdata dir exists" test -d /mnt/data/appdata
+assert "compose dir exists" test -d /mnt/data/compose
+assert "backup dir exists" test -d /mnt/data/backup
+assert "share dir exists" test -d /mnt/data/share
+
+assert_eq "appdata owner" "svc_docker:grp_docker" "$(stat -c '%U:%G' /mnt/data/appdata)"
+assert_eq "compose owner" "svc_docker:grp_docker" "$(stat -c '%U:%G' /mnt/data/compose)"
+assert_eq "appdata mode" "750" "$(stat -c '%a' /mnt/data/appdata)"
+
+# Idempotent
+bash "$SCRIPT_DIR/07-data-dirs.sh"
+assert "idempotent: no error on rerun" true
+
+# Wrong ownership detection: chown to root, re-run, should warn and fix
+chown root:root /mnt/data/appdata
+output=$(bash "$SCRIPT_DIR/07-data-dirs.sh" 2>&1)
+if echo "$output" | grep -q "WARN"; then
+  echo "  PASS: warns about wrong ownership"; ((pass++))
+else
+  echo "  FAIL: warns about wrong ownership"; ((fail++))
+fi
+assert_eq "ownership corrected" "svc_docker:grp_docker" "$(stat -c '%U:%G' /mnt/data/appdata)"
+
+# ============================================================
+echo ""
+echo "=== 08-register-shares.sh ==="
+reset_mocks
+
+bash "$SCRIPT_DIR/08-register-shares.sh"
+assert "sf-uuids file created" test -f "$SCRIPT_DIR/.sf-uuids"
+assert "SF_COMPOSE_UUID set" grep -q "SF_COMPOSE_UUID=" "$SCRIPT_DIR/.sf-uuids"
+assert "SF_APPDATA_UUID set" grep -q "SF_APPDATA_UUID=" "$SCRIPT_DIR/.sf-uuids"
+assert "SF_BACKUP_UUID set" grep -q "SF_BACKUP_UUID=" "$SCRIPT_DIR/.sf-uuids"
+assert "SF_SHARE_UUID set" grep -q "SF_SHARE_UUID=" "$SCRIPT_DIR/.sf-uuids"
+
+# Idempotent: mock now returns existing shares
+echo '{"total":4,"data":[
+  {"uuid":"existing-1","name":"compose"},
+  {"uuid":"existing-2","name":"appdata"},
+  {"uuid":"existing-3","name":"backup"},
+  {"uuid":"existing-4","name":"share"}
+]}' > /tmp/omv-mock-shares.json
+
+bash "$SCRIPT_DIR/08-register-shares.sh"
+assert "idempotent: reuses existing UUIDs" grep -q "existing-1" "$SCRIPT_DIR/.sf-uuids"
+
+# ============================================================
+echo ""
+echo "=== 09-configure-compose.sh ==="
+reset_mocks
+
+# Setup: sf-uuids from previous step
+cat > "$SCRIPT_DIR/.sf-uuids" <<'EOF'
+SF_COMPOSE_UUID=uuid-compose
+SF_APPDATA_UUID=uuid-appdata
+SF_BACKUP_UUID=uuid-backup
+SF_SHARE_UUID=uuid-share
+EOF
+
+# Case 1: empty settings -- should apply without prompt
+echo '{"sharedfolderref":"","datasharedfolderref":"","backupsharedfolderref":"","composeowner":"","composegroup":"","mode":"750","fileperms":"640"}' > /tmp/omv-mock-compose.json
+
+bash "$SCRIPT_DIR/09-configure-compose.sh"
+assert "applies to empty settings" test -f /tmp/omv-mock-compose-last-set.json
+
+# Case 2: non-empty settings that differ + OMV_NONINTERACTIVE=1 -- should skip
+rm -f /tmp/omv-mock-compose-last-set.json
+echo '{"sharedfolderref":"other-uuid","datasharedfolderref":"other","backupsharedfolderref":"other","composeowner":"root","composegroup":"root","mode":"750","fileperms":"640"}' > /tmp/omv-mock-compose.json
+
+OMV_NONINTERACTIVE=1 bash "$SCRIPT_DIR/09-configure-compose.sh"
+assert "NONINTERACTIVE skips overwrite" test ! -f /tmp/omv-mock-compose-last-set.json
+
+# Case 3: non-empty settings that differ + OMV_FORCE=1 -- should apply
+OMV_FORCE=1 bash "$SCRIPT_DIR/09-configure-compose.sh"
+assert "FORCE applies overwrite" test -f /tmp/omv-mock-compose-last-set.json
+
+# Case 4: settings already match -- no-op
+rm -f /tmp/omv-mock-compose-last-set.json
+echo '{"sharedfolderref":"uuid-compose","datasharedfolderref":"uuid-appdata","backupsharedfolderref":"uuid-backup","composeowner":"svc_docker","composegroup":"grp_docker","mode":"750","fileperms":"640"}' > /tmp/omv-mock-compose.json
+
+bash "$SCRIPT_DIR/09-configure-compose.sh"
+assert "matching settings: still applies (idempotent set)" true
+
+# ============================================================
+echo ""
+echo "=== 10-scheduled-jobs.sh ==="
+reset_mocks
+
+bash "$SCRIPT_DIR/10-scheduled-jobs.sh"
+assert "jobs created file exists" test -f /tmp/omv-mock-jobs-created.json
+job_count=$(wc -l < /tmp/omv-mock-jobs-created.json)
+assert_eq "3 jobs created" "3" "$job_count"
+
+# Idempotent: mock returns existing jobs
+echo '{"total":3,"data":[
+  {"uuid":"j1","comment":"omv-setup: daily backup"},
+  {"uuid":"j2","comment":"omv-setup: weekly update"},
+  {"uuid":"j3","comment":"omv-setup: weekly prune"}
+]}' > /tmp/omv-mock-jobs.json
+rm -f /tmp/omv-mock-jobs-created.json
+
+bash "$SCRIPT_DIR/10-scheduled-jobs.sh"
+if [[ -f /tmp/omv-mock-jobs-created.json ]]; then
+  echo "  FAIL: idempotent -- should not create jobs again"; ((fail++))
+else
+  echo "  PASS: idempotent -- no duplicate jobs"; ((pass++))
+fi
+
+# ============================================================
+echo ""
+echo "=== 11-deploy.sh ==="
+reset_mocks
+
+bash "$SCRIPT_DIR/11-deploy.sh"
+assert "omv-salt was called" test -f /tmp/omv-mock-salt.log
+assert "called with 'deploy run compose'" grep -q "deploy run compose" /tmp/omv-mock-salt.log
+
+# ============================================================
+echo ""
+echo "================================"
+echo "Results: $pass passed, $fail failed"
+echo "================================"
+
+[[ $fail -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
Modular setup scripts at tools/omv-setup/ that automate the full Docker + Compose configuration on OpenMediaVault via omv-rpc. Creates groups (grp_docker + system docker), service user (svc_docker), data directories, OMV shared folders, compose plugin config, and scheduled backup/update/prune jobs. All configurable via env vars, safe overwrite prompts, and testable in Docker with mocked OMV CLIs.