### PR TITLE
Allow pull on multiple selected compose files

### DIFF
--- a/usr/share/openmediavault/workbench/component.d/omv-services-compose-files-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-compose-files-datatable-page.yaml
@@ -423,7 +423,6 @@ data:
         tooltip: _("pull")
         enabledConstraints:
           minSelected: 1
-          maxSelected: 1
         execute:
           type: taskDialog
           taskDialog:
@@ -432,9 +431,9 @@ data:
               startOnInit: true
               request:
                 service: Compose
-                method: doCommand
+                method: doCommandList
                 params:
-                  uuid: "{{ _selected[0].uuid }}"
+                  uuid: "{{ _selected | map('get', 'uuid') | join(',') }}"
                   command: "pull"
       - type: iconButton
         icon: mdi:list-status


### PR DESCRIPTION
## Problem

The `pull` button in the files datatable was limited to a single selection 
(`maxSelected: 1`) and used `doCommand` (single UUID), while `up` and `down` 
already supported multi-select via `doCommandList`.

The backend already handles `pull` correctly when 
called through `doCommandList`, so no backend changes were needed.

## Changes

Only one file changed: `omv-services-compose-files-datatable-page.yaml`

- Removed `maxSelected: 1` constraint from the pull button
- Changed method from `doCommand` to `doCommandList`
- Changed param from `uuid: "{{ _selected[0].uuid }}"` to 
  `uuids: "{{ _selected | map('get', 'uuid') | join(',') }}"`

This makes pull consistent with `up` and `down`, which already use the 
same pattern.

## Testing

Tested on OMV 8.1.24 with multiple compose files selected, pull now runs 
sequentially on all selected files, consistent with the behavior of `up` 
and `down`.